### PR TITLE
Allow Justification on Buttons, ToggleButtons and Labels

### DIFF
--- a/include/SFGUI/Alignment.hpp
+++ b/include/SFGUI/Alignment.hpp
@@ -40,7 +40,7 @@ class SFGUI_API Alignment : public Bin, public Misc {
 
 	private:
 		void HandleSizeChange() override;
-		void HandleAlignmentChange( const sf::Vector2f& old_alignment ) override;
+		void HandleAlignmentChange( const Misc::Alignment& old_alignment ) override;
 
 		void UpdateChild();
 

--- a/include/SFGUI/Button.hpp
+++ b/include/SFGUI/Button.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SFGUI/Bin.hpp>
+#include <SFGUI/Misc.hpp>
 
 #include <SFML/System/String.hpp>
 #include <memory>
@@ -11,7 +12,7 @@ class Image;
 
 /** Pushbutton.
  */
-class SFGUI_API Button : public Bin {
+class SFGUI_API Button : public Bin, public Misc {
 	public:
 		typedef std::shared_ptr<Button> Ptr; //!< Shared pointer.
 		typedef std::shared_ptr<const Button> PtrConst; //!< Shared pointer.

--- a/include/SFGUI/Misc.hpp
+++ b/include/SFGUI/Misc.hpp
@@ -15,21 +15,49 @@ class SFGUI_API Misc {
 		 */
 		virtual ~Misc() = default;
 
+		/** Widget Justification
+		*/
+		enum class Justify :char {
+			CENTRE = 0, /*!< No Justification. */
+			LEFT, /*!< Left justificiation. */
+			RIGHT /*!< RIght justification. */
+		};
+
+		/** Alignment Structure
+		* Alignment sf::Vector2f
+		* Justification char
+		*/
+
+		struct Alignment {
+			sf::Vector2f position;
+			Justify justification;
+		};
+
 		/** Set alignment
 		 * @param alignment Alignment (0..1 for x and y).
 		 */
-		void SetAlignment( const sf::Vector2f& alignment );
+		void SetAlignment( const sf::Vector2f position, const Justify justification = Misc::Justify::CENTRE );
 
 		/** Get alignment.
 		 * @return Alignment.
 		 */
-		const sf::Vector2f& GetAlignment() const;
+		const Alignment& GetAlignment() const;
+
+		/** Equal operator
+		*@return bool
+		*/
+		friend bool operator== ( Alignment &a1, Alignment &a2 );
+
+		/** Not equal operator
+		* @return bool
+		*/
+		friend bool operator!= ( Alignment &a1, Alignment &a2 );
 
 	protected:
-		virtual void HandleAlignmentChange( const sf::Vector2f& old_alignment );
+		virtual void HandleAlignmentChange( const Alignment& old_alignment );
 
 	private:
-		sf::Vector2f m_alignment;
+		Alignment m_alignment;
 };
 
 }

--- a/include/SFGUI/ToggleButton.hpp
+++ b/include/SFGUI/ToggleButton.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SFGUI/Button.hpp>
+#include <SFGUI/Misc.hpp>
 
 #include <memory>
 

--- a/src/SFGUI/Alignment.cpp
+++ b/src/SFGUI/Alignment.cpp
@@ -39,7 +39,7 @@ void Alignment::HandleSizeChange() {
 	UpdateChild();
 }
 
-void Alignment::HandleAlignmentChange( const sf::Vector2f& /*old_alignment*/ ) {
+void Alignment::HandleAlignmentChange( const Misc::Alignment& /*old_alignment*/ ) {
 	UpdateChild();
 }
 
@@ -64,8 +64,8 @@ void Alignment::UpdateChild() {
 #endif
 	}
 
-	allocation.left = spare_space.x * GetAlignment().x;
-	allocation.top = spare_space.y * GetAlignment().y;
+	allocation.left = spare_space.x * GetAlignment().position.x;
+	allocation.top = spare_space.y * GetAlignment().position.y;
 	allocation.width -= spare_space.x;
 	allocation.height -= spare_space.y;
 

--- a/src/SFGUI/Button.cpp
+++ b/src/SFGUI/Button.cpp
@@ -9,6 +9,7 @@ namespace sfg {
 Button::Ptr Button::Create( const sf::String& label ) {
 	auto ptr = Ptr( new Button );
 	ptr->SetLabel( label );
+	ptr->SetAlignment( sf::Vector2f(0.5f, 0.5f), Misc::Justify::CENTRE );
 	return ptr;
 }
 

--- a/src/SFGUI/Engines/BREW/Button.cpp
+++ b/src/SFGUI/Engines/BREW/Button.cpp
@@ -45,22 +45,40 @@ std::unique_ptr<RenderQueue> BREW::CreateButtonDrawable( std::shared_ptr<const B
 		sf::Text text( button->GetLabel(), *font, font_size );
 		auto offset = ( button->GetState() == Button::State::ACTIVE ) ? border_width : 0.f;
 		sfg::Widget::PtrConst child( button->GetChild() );
+		Misc::Alignment nAlignment = button->GetAlignment();
+		sf::Vector2f nPosition;
+		nPosition.y = button->GetAllocation().height / nAlignment.position.y - metrics.y / 2.f + offset;
 
 		if( !child ) {
-			text.setPosition(
-				button->GetAllocation().width / 2.f - metrics.x / 2.f + offset,
-				button->GetAllocation().height / 2.f - metrics.y / 2.f + offset
-			);
+			nPosition.x = button->GetAllocation().width / nAlignment.position.x;
+				switch ( nAlignment.justification ) {
+			case Misc::Justify::LEFT:
+				nPosition.x += offset;
+				break;
+			case Misc::Justify::RIGHT:
+				nPosition.x -= metrics.x + offset;
+				break;
+			default:
+				nPosition.x += metrics.x / 2.f + offset;
+				break;
+			}
 		}
 		else {
 			float width( button->GetAllocation().width - spacing - child->GetAllocation().width );
-
-			text.setPosition(
-				child->GetAllocation().width + spacing + (width / 2.f - metrics.x / 2.f) + offset,
-				button->GetAllocation().height / 2.f - metrics.y / 2.f + offset
-			);
+			nPosition.x = child->GetAllocation().width + spacing + width / nAlignment.position.x;
+			switch ( nAlignment.justification ) {
+			case Misc::Justify::LEFT:
+				nPosition.x +=  offset;
+				break;
+			case Misc::Justify::RIGHT:
+				nPosition.x -=  metrics.x + offset;
+				break;
+			default:
+				nPosition.x -= metrics.x / 2.f - offset;
+				break;
+			}
 		}
-
+		text.setPosition( nPosition.x, nPosition.y );
 		text.setColor( color );
 		queue->Add( Renderer::Get().CreateText( text ) );
 	}

--- a/src/SFGUI/Engines/BREW/Frame.cpp
+++ b/src/SFGUI/Engines/BREW/Frame.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<RenderQueue> BREW::CreateFrameDrawable( std::shared_ptr<const Fr
 	auto label_start_x = line_height;
 	auto label_end_x = line_height;
 
-	auto alignment = frame->GetAlignment().x;
+	auto alignment = frame->GetAlignment().position.x;
 
 	if( frame->GetLabel().getSize() > 0 ) {
 		auto metrics = GetTextStringMetrics( frame->GetLabel(), *font, font_size );

--- a/src/SFGUI/Engines/BREW/Image.cpp
+++ b/src/SFGUI/Engines/BREW/Image.cpp
@@ -14,8 +14,8 @@ std::unique_ptr<RenderQueue> BREW::CreateImageDrawable( std::shared_ptr<const Im
 	queue->Add(
 		Renderer::Get().CreateSprite(
 			sf::FloatRect(
-				( image->GetAllocation().width - image->GetRequisition().x ) * image->GetAlignment().x,
-				( image->GetAllocation().height - image->GetRequisition().y ) * image->GetAlignment().y,
+				( image->GetAllocation().width - image->GetRequisition().x ) * image->GetAlignment().position.x,
+				( image->GetAllocation().height - image->GetRequisition().y ) * image->GetAlignment().position.y,
 				static_cast<float>( image->GetImage().getSize().x ),
 				static_cast<float>( image->GetImage().getSize().y )
 			),

--- a/src/SFGUI/Engines/BREW/Label.cpp
+++ b/src/SFGUI/Engines/BREW/Label.cpp
@@ -21,10 +21,25 @@ std::unique_ptr<RenderQueue> BREW::CreateLabelDrawable( std::shared_ptr<const La
 
 	if( !label->GetLineWrap() ) {
 		// Calculate alignment when word wrap is disabled.
-		sf::Vector2f avail_space( label->GetAllocation().width - label->GetRequisition().x, label->GetAllocation().height - label->GetRequisition().y );
-		sf::Vector2f position( avail_space.x * label->GetAlignment().x, avail_space.y * label->GetAlignment().y );
+		auto metrics = GetTextStringMetrics( label->GetWrappedText(), *font, font_size );
+		metrics.y = GetFontLineHeight( *font, font_size );
 
-		vis_label.setPosition( position.x, position.y );
+		Misc::Alignment nAlignment = label->GetAlignment();
+		sf::Vector2f nPosition;
+		nPosition.x = label->GetAllocation().width / nAlignment.position.x;
+		nPosition.y = label->GetAllocation().height / nAlignment.position.y - metrics.y / 2.f;
+
+		switch ( nAlignment.justification ) {
+		case Misc::Justify::LEFT:
+			break;
+		case Misc::Justify::RIGHT:
+			nPosition.x -= metrics.x;
+		default:
+			nPosition.x += metrics.x / 2.f;
+			break;
+		}
+
+		vis_label.setPosition( nPosition.x, nPosition.y );
 	}
 
 	queue->Add( Renderer::Get().CreateText( vis_label ) );

--- a/src/SFGUI/Engines/BREW/ToggleButton.cpp
+++ b/src/SFGUI/Engines/BREW/ToggleButton.cpp
@@ -44,11 +44,23 @@ std::unique_ptr<RenderQueue> BREW::CreateToggleButtonDrawable( std::shared_ptr<c
 		sf::Text text( button->GetLabel(), *font, font_size );
 		auto offset = ( ( button->GetState() == Button::State::ACTIVE ) || button->IsActive() ) ? border_width : 0.f;
 
-		text.setPosition(
-			button->GetAllocation().width / 2.f - metrics.x / 2.f + offset,
-			button->GetAllocation().height / 2.f - metrics.y / 2.f + offset
-		);
+		Misc::Alignment nAlignment = button->GetAlignment();
+		sf::Vector2f nPosition;
+		nPosition.x = button->GetAllocation().width / nAlignment.position.x;
+		nPosition.y = button->GetAllocation().height / nAlignment.position.y - metrics.y / 2.f + offset;
 
+		switch ( nAlignment.justification ) {
+		case Misc::Justify::LEFT:
+			nPosition.x += offset;
+			break;
+		case Misc::Justify::RIGHT:
+			nPosition.x -= metrics.x + offset;
+		default:
+			nPosition.x += metrics.x / 2.f + offset;
+			break;
+		}
+
+		text.setPosition( nPosition.x, nPosition.y );
 		text.setColor( color );
 		queue->Add( Renderer::Get().CreateText( text ) );
 	}

--- a/src/SFGUI/Image.cpp
+++ b/src/SFGUI/Image.cpp
@@ -12,7 +12,7 @@ namespace sfg {
 
 Image::Image( const sf::Image& image )
 {
-	SetAlignment( sf::Vector2f( .5f, .5f ) );
+	SetAlignment( sf::Vector2f( .5f, .5f ), Misc::Justify::CENTRE );
 	SetImage( image );
 }
 

--- a/src/SFGUI/Label.cpp
+++ b/src/SFGUI/Label.cpp
@@ -11,13 +11,14 @@ Label::Label( const sf::String& text ) :
 	m_text( text ),
 	m_wrap( false )
 {
-	SetAlignment( sf::Vector2f( .5f, .5f ) );
+	SetAlignment( sf::Vector2f( .5f, .5f ), Misc::Justify::CENTRE);
 	Invalidate();
 }
 
 Label::Ptr Label::Create( const sf::String& text ) {
 	Ptr label( new Label( text ) );
 	label->RequestResize();
+	label->SetAlignment( sf::Vector2f( 0.5f, 0.5f ), Misc::Justify::CENTRE );
 	return label;
 }
 

--- a/src/SFGUI/Misc.cpp
+++ b/src/SFGUI/Misc.cpp
@@ -4,22 +4,35 @@
 
 namespace sfg {
 
-void Misc::SetAlignment( const sf::Vector2f& alignment ) {
-	sf::Vector2f old_alignment( m_alignment );
-
-	m_alignment.x = std::max( 0.f, std::min( 1.f, alignment.x ) );
-	m_alignment.y = std::max( 0.f, std::min( 1.f, alignment.y ) );
-
-	if( old_alignment != m_alignment ) {
-		HandleAlignmentChange( old_alignment );
+	bool operator==( Misc::Alignment& a1, Misc::Alignment& a2 ) {
+		return ( a1.position.x == a2.position.x &&
+			a1.position.y == a2.position.y &&
+			a1.justification == a2.justification );
 	}
-}
 
-const sf::Vector2f& Misc::GetAlignment() const {
+	bool operator!=( Misc::Alignment& a1, Misc::Alignment& a2 ) {
+		return ( a1.position.x != a2.position.x &&
+			a1.position.y != a2.position.y &&
+			a1.justification != a2.justification );
+	}
+	
+	void Misc::SetAlignment( const sf::Vector2f position, const Misc::Justify justification ) {
+		Misc::Alignment old_alignment( m_alignment );
+
+		m_alignment.position.x = std::max( 0.f, std::min( 1.f, position.x ) );
+		m_alignment.position.y = std::max( 0.f, std::min( 1.f, position.y ) );
+		m_alignment.justification = justification;
+
+		if ( old_alignment != m_alignment ) {
+			HandleAlignmentChange( old_alignment );
+		}
+	}
+
+const Misc::Alignment& Misc::GetAlignment() const {
 	return m_alignment;
 }
 
-void Misc::HandleAlignmentChange( const sf::Vector2f& /*old_alignment*/ ) {
+void Misc::HandleAlignmentChange( const Misc::Alignment& /*old_alignment*/ ) {
 }
 
 }

--- a/src/SFGUI/ResourceManager.cpp
+++ b/src/SFGUI/ResourceManager.cpp
@@ -183,7 +183,7 @@ void ResourceManager::AddImage( const std::string& path, std::shared_ptr<const s
 }
 
 void ResourceManager::SetDefaultFont( std::shared_ptr<const sf::Font> font ) {
-	AddFont( "", font );
+	AddFont( "Default", font );
 }
 
 }

--- a/src/SFGUI/ResourceManager.cpp
+++ b/src/SFGUI/ResourceManager.cpp
@@ -183,7 +183,7 @@ void ResourceManager::AddImage( const std::string& path, std::shared_ptr<const s
 }
 
 void ResourceManager::SetDefaultFont( std::shared_ptr<const sf::Font> font ) {
-	AddFont( "Default", font );
+	AddFont( "", font );
 }
 
 }

--- a/src/SFGUI/ToggleButton.cpp
+++ b/src/SFGUI/ToggleButton.cpp
@@ -16,6 +16,7 @@ ToggleButton::ToggleButton() :
 ToggleButton::Ptr ToggleButton::Create( const sf::String& label ) {
 	Ptr button( new ToggleButton );
 	button->SetLabel( label );
+	button->SetAlignment( sf::Vector2f( 0.5f, 0.5f ), Misc::Justify::CENTRE );
 	return button;
 }
 


### PR DESCRIPTION
This code will allow buttons, togglebuttons and labels to be justified.  It currently does not validate or default it the provided position to a valid one.  A position can be provided to appear outside of the widgets allocation and it will do so (displaying nothing).

I'll correct that before the final pull request, this is just to get initial feedback before too much work is done.

Left Justified aligns on the start of the text.
Centre Justified (default) aligns on the centre of the text.
Right Justified aligns on the end of the text.