### PR TITLE
Made SFGUI use the new SFML function

### DIFF
--- a/examples/CustomWidget.cpp
+++ b/examples/CustomWidget.cpp
@@ -130,7 +130,7 @@ class MyCustomWidget : public sfg::Widget {
 				sf::Text text( GetLabel(), *font, font_size );
 
 				// Set the text color to white.
-				text.setColor( sf::Color::White );
+				text.setFillColor( sf::Color::White );
 
 				// Randomize the applied offset a bit
 				auto x_offset = ( GetState() == State::ACTIVE ) ? static_cast<float>( m_distribution( m_generator ) ) : 0.f;

--- a/src/SFGUI/Canvas.cpp
+++ b/src/SFGUI/Canvas.cpp
@@ -537,7 +537,7 @@ void Canvas::SetupShader() {
 	m_vertex_location = GetAttributeLocation( *m_shader, "vertex" );
 	m_texture_coordinate_location = GetAttributeLocation( *m_shader, "texture_coordinate" );
 
-	m_shader->setParameter( "texture0", m_render_texture->getTexture() );
+	m_shader->setUniform( "texture0", m_render_texture->getTexture() );
 }
 
 }

--- a/src/SFGUI/Engines/BREW/Button.cpp
+++ b/src/SFGUI/Engines/BREW/Button.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<RenderQueue> BREW::CreateButtonDrawable( std::shared_ptr<const B
 			);
 		}
 
-		text.setColor( color );
+		text.setFillColor( color );
 		queue->Add( Renderer::Get().CreateText( text ) );
 	}
 

--- a/src/SFGUI/Engines/BREW/CheckButton.cpp
+++ b/src/SFGUI/Engines/BREW/CheckButton.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<RenderQueue> BREW::CreateCheckButtonDrawable( std::shared_ptr<co
 			box_size + spacing,
 			check->GetAllocation().height / 2.f - metrics.y / 2.f
 		);
-		text.setColor( color );
+		text.setFillColor( color );
 		queue->Add( Renderer::Get().CreateText( text ) );
 	}
 

--- a/src/SFGUI/Engines/BREW/ComboBox.cpp
+++ b/src/SFGUI/Engines/BREW/ComboBox.cpp
@@ -87,7 +87,7 @@ std::unique_ptr<RenderQueue> BREW::CreateComboBoxDrawable( std::shared_ptr<const
 
 			sf::Text text( combo_box->GetItem( item_index ), *font, font_size );
 			text.setPosition( item_position.x + padding, item_position.y + padding );
-			text.setColor( color );
+			text.setFillColor( color );
 			queue->Add( Renderer::Get().CreateText( text ) );
 
 			item_position.y += item_size.y;
@@ -100,7 +100,7 @@ std::unique_ptr<RenderQueue> BREW::CreateComboBoxDrawable( std::shared_ptr<const
 			border_width + padding,
 			combo_box->GetAllocation().height / 2.f - line_height / 2.f
 		);
-		text.setColor( color );
+		text.setFillColor( color );
 		queue->Add( Renderer::Get().CreateText( text ) );
 	}
 

--- a/src/SFGUI/Engines/BREW/Entry.cpp
+++ b/src/SFGUI/Engines/BREW/Entry.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<RenderQueue> BREW::CreateEntryDrawable( std::shared_ptr<const En
 
 	auto line_height = GetFontLineHeight( *font, font_size );
 	sf::Text vis_label( entry->GetVisibleText(), *font, font_size );
-	vis_label.setColor( text_color );
+	vis_label.setFillColor( text_color );
 	vis_label.setPosition( text_padding, entry->GetAllocation().height / 2.f - line_height / 2.f );
 
 	queue->Add( Renderer::Get().CreateText( vis_label ) );

--- a/src/SFGUI/Engines/BREW/Frame.cpp
+++ b/src/SFGUI/Engines/BREW/Frame.cpp
@@ -65,7 +65,7 @@ std::unique_ptr<RenderQueue> BREW::CreateFrameDrawable( std::shared_ptr<const Fr
 
 		sf::Text text( frame->GetLabel(), *font, font_size );
 		text.setPosition( label_start_x + label_padding, border_width / 2.f );
-		text.setColor( color );
+		text.setFillColor( color );
 		queue->Add( Renderer::Get().CreateText( text ) );
 	}
 

--- a/src/SFGUI/Engines/BREW/Label.cpp
+++ b/src/SFGUI/Engines/BREW/Label.cpp
@@ -17,7 +17,7 @@ std::unique_ptr<RenderQueue> BREW::CreateLabelDrawable( std::shared_ptr<const La
 	std::unique_ptr<RenderQueue> queue( new RenderQueue );
 
 	sf::Text vis_label( label->GetWrappedText(), *font, font_size );
-	vis_label.setColor( font_color );
+	vis_label.setFillColor( font_color );
 
 	if( !label->GetLineWrap() ) {
 		// Calculate alignment when word wrap is disabled.

--- a/src/SFGUI/Engines/BREW/SpinButton.cpp
+++ b/src/SFGUI/Engines/BREW/SpinButton.cpp
@@ -87,7 +87,7 @@ std::unique_ptr<RenderQueue> BREW::CreateSpinButtonDrawable( std::shared_ptr<con
 
 	auto line_height = GetFontLineHeight( *font, font_size );
 	sf::Text vis_label( spinbutton->GetVisibleText(), *font, font_size );
-	vis_label.setColor( text_color );
+	vis_label.setFillColor( text_color );
 	vis_label.setPosition( text_padding, spinbutton->GetAllocation().height / 2.f - line_height / 2.f );
 
 	queue->Add( Renderer::Get().CreateText( vis_label ) );

--- a/src/SFGUI/Engines/BREW/ToggleButton.cpp
+++ b/src/SFGUI/Engines/BREW/ToggleButton.cpp
@@ -49,7 +49,7 @@ std::unique_ptr<RenderQueue> BREW::CreateToggleButtonDrawable( std::shared_ptr<c
 			button->GetAllocation().height / 2.f - metrics.y / 2.f + offset
 		);
 
-		text.setColor( color );
+		text.setFillColor( color );
 		queue->Add( Renderer::Get().CreateText( text ) );
 	}
 

--- a/src/SFGUI/Engines/BREW/Window.cpp
+++ b/src/SFGUI/Engines/BREW/Window.cpp
@@ -161,7 +161,7 @@ std::unique_ptr<RenderQueue> BREW::CreateWindowDrawable( std::shared_ptr<const W
 		);
 
 		title_text.setPosition( title_position );
-		title_text.setColor( title_text_color );
+		title_text.setFillColor( title_text_color );
 
 		queue->Add( Renderer::Get().CreateText( title_text ) );
 	}

--- a/src/SFGUI/Renderer.cpp
+++ b/src/SFGUI/Renderer.cpp
@@ -105,7 +105,7 @@ RendererViewport::Ptr Renderer::CreateViewport() {
 Primitive::Ptr Renderer::CreateText( const sf::Text& text ) {
 	const auto& font = *text.getFont();
 	auto character_size = text.getCharacterSize();
-	auto color = text.getColor();
+	auto color = text.getFillColor();
 
 	auto atlas_offset = LoadFont( font, character_size );
 

--- a/src/SFGUI/Renderers/NonLegacyRenderer.cpp
+++ b/src/SFGUI/Renderers/NonLegacyRenderer.cpp
@@ -315,7 +315,7 @@ void NonLegacyRenderer::DisplayImpl() const {
 		if( m_window_size.x && m_window_size.y ) {
 			const_cast<NonLegacyRenderer*>( this )->Invalidate( INVALIDATE_VERTEX | INVALIDATE_TEXTURE );
 
-			m_shader.setParameter( "viewport_parameters", 2.f / static_cast<float>( m_window_size.x ), -2.f / static_cast<float>( m_window_size.y ) );
+			m_shader.setUniform( "viewport_parameters", sf::Glsl::Vec2( 2.f / static_cast<float>( m_window_size.x ), -2.f / static_cast<float>( m_window_size.y ) ) );
 
 			const_cast<NonLegacyRenderer*>( this )->SetupFBO( m_window_size.x, m_window_size.y );
 		}
@@ -354,7 +354,7 @@ void NonLegacyRenderer::DisplayImpl() const {
 			CheckGLError( glClear( GL_COLOR_BUFFER_BIT ) );
 		}
 
-		m_shader.setParameter( "texture0", *( m_texture_atlas[0] ) );
+		m_shader.setUniform( "texture0", *( m_texture_atlas[0] ) );
 		sf::Shader::bind( &m_shader );
 
 		CheckGLError( GLEXT_glBindVertexArray( m_vao ) );
@@ -401,7 +401,7 @@ void NonLegacyRenderer::DisplayImpl() const {
 					if( batch.atlas_page != current_atlas_page ) {
 						current_atlas_page = batch.atlas_page;
 
-						m_shader.setParameter( "texture0", *( m_texture_atlas[static_cast<std::size_t>( current_atlas_page )] ) );
+						m_shader.setUniform( "texture0", *( m_texture_atlas[static_cast<std::size_t>( current_atlas_page )] ) );
 					}
 
 					CheckGLError( glDrawRangeElements(
@@ -772,7 +772,7 @@ void NonLegacyRenderer::SetupFBO( int width, int height ) {
 		m_fbo_vertex_location = GetAttributeLocation( m_fbo_shader, "vertex" );
 		m_fbo_texture_coordinate_location = GetAttributeLocation( m_fbo_shader, "texture_coordinate" );
 
-		m_fbo_shader.setParameter( "texture0", m_frame_buffer_texture );
+		m_fbo_shader.setUniform( "texture0", m_frame_buffer_texture );
 
 		CheckGLError( GLEXT_glGenBuffers( 1, &m_fbo_vbo ) );
 		CheckGLError( GLEXT_glBindBuffer( GLEXT_GL_ARRAY_BUFFER, m_fbo_vbo ) );


### PR DESCRIPTION
`sf::Text::setColor` :arrow_forward: `sf::Text::setFillColor`  
`sf::Text::getColor` :arrow_forward: `sf::Text::getFillColor`  
`sf::Shader::setParameter` :arrow_forward: `sf::Shader::setUniform`

Deprecation warnings be gone!
