### PR TITLE
Fixed sfg::Canvas::Draw vertex_count parameter type being unsigned in…

### DIFF
--- a/include/SFGUI/Canvas.hpp
+++ b/include/SFGUI/Canvas.hpp
@@ -68,7 +68,7 @@ class SFGUI_API Canvas : public Widget {
 		 * @param type Type of primitives to draw.
 		 * @param states Render states to use for drawing.
 		 */
-		void Draw( const sf::Vertex* vertices, unsigned int vertex_count, sf::PrimitiveType type, const sf::RenderStates& states = sf::RenderStates::Default );
+		void Draw( const sf::Vertex* vertices, std::size_t vertex_count, sf::PrimitiveType type, const sf::RenderStates& states = sf::RenderStates::Default );
 
 		/** Set the sf::View that the canvas should use when performing SFML drawing.
 		 * @param view The sf::View that the canvas should when performing SFML drawing.

--- a/src/SFGUI/Canvas.cpp
+++ b/src/SFGUI/Canvas.cpp
@@ -297,7 +297,7 @@ void Canvas::Draw( const sf::Drawable& drawable, const sf::RenderStates& states 
 	m_render_texture->draw( drawable, states );
 }
 
-void Canvas::Draw( const sf::Vertex* vertices, unsigned int vertex_count, sf::PrimitiveType type, const sf::RenderStates& states ) {
+void Canvas::Draw( const sf::Vertex* vertices, std::size_t vertex_count, sf::PrimitiveType type, const sf::RenderStates& states ) {
 	m_render_texture->draw( vertices, vertex_count, type, states );
 }
 


### PR DESCRIPTION
…t instead of std::size_t as it is in SFML. (#38)