### PR TITLE
using .toAnsiString() instead of static_cast that caused link error

### DIFF
--- a/examples/GuessMyNumber.cpp
+++ b/examples/GuessMyNumber.cpp
@@ -66,7 +66,7 @@ int main() {
 		// Validate number.
 		unsigned int buf_number( 0 );
 
-		std::stringstream sstr( static_cast<std::string>( current_number_entry->GetText() ) );
+		std::stringstream sstr( current_number_entry->GetText().toAnsiString() );
 		sstr >> buf_number;
 
 		if( buf_number < 1 || buf_number > 100 ) {


### PR DESCRIPTION
see comment