### PR TITLE
Don't redefine WIN32_LEAN_AND_MEAN

### DIFF
--- a/include/SFGUI/Config.hpp
+++ b/include/SFGUI/Config.hpp
@@ -6,7 +6,10 @@
 
 #if defined( _WIN32 ) || defined( __WIN32__ )
 	#define SFGUI_SYSTEM_WINDOWS
-	#define WIN32_LEAN_AND_MEAN
+
+	#if !defined( WIN32_LEAN_AND_MEAN )
+		#define WIN32_LEAN_AND_MEAN
+	#endif
 
 	#if !defined( NOMINMAX )
 		#define NOMINMAX


### PR DESCRIPTION
If it has already been defined then this causes a compiler warning (vs2017 for me)