### PR TITLE
Add missing include <string> necessary to use std::string

### DIFF
--- a/include/SFGUI/Renderer.hpp
+++ b/include/SFGUI/Renderer.hpp
@@ -5,10 +5,11 @@
 
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/Rect.hpp>
-#include <vector>
-#include <map>
 #include <deque>
+#include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace sf {
 class Window;


### PR DESCRIPTION
Note virtual const std::string& GetName() const = 0; on 259.