### PR TITLE
Fixed deprecation and conversion warnings

### DIFF
--- a/src/SFGUI/Canvas.cpp
+++ b/src/SFGUI/Canvas.cpp
@@ -367,14 +367,14 @@ void Canvas::Clear( const sf::Color& color, bool depth ) {
 
 		m_render_texture = std::make_shared<sf::RenderTexture>();
 
-		if( !m_render_texture->create( static_cast<unsigned int>( std::floor( allocation.width + .5f ) ), static_cast<unsigned int>( std::floor( allocation.height + .5f ) ), m_depth ) ) {
+		if( !m_render_texture->create( static_cast<unsigned int>( std::floor( allocation.width + .5f ) ), static_cast<unsigned int>( std::floor( allocation.height + .5f ) ), sf::ContextSettings( m_depth ) ) ) {
 #if defined( SFGUI_DEBUG )
 			std::cerr << "SFGUI warning: Canvas failed to create internal SFML RenderTexture.\n";
 #endif
 		}
 	}
 	else if( m_resize ) {
-		if( !m_render_texture->create( static_cast<unsigned int>( std::floor( allocation.width + .5f ) ), static_cast<unsigned int>( std::floor( allocation.height + .5f ) ), m_depth ) ) {
+		if( !m_render_texture->create( static_cast<unsigned int>( std::floor( allocation.width + .5f ) ), static_cast<unsigned int>( std::floor( allocation.height + .5f ) ), sf::ContextSettings( m_depth ) ) ) {
 #if defined( SFGUI_DEBUG )
 			std::cerr << "SFGUI warning: Canvas failed to create internal SFML RenderTexture.\n";
 #endif
@@ -443,14 +443,14 @@ void Canvas::Bind() {
 
 		m_render_texture = std::make_shared<sf::RenderTexture>();
 
-		if( !m_render_texture->create( static_cast<unsigned int>( std::floor( allocation.width + .5f ) ), static_cast<unsigned int>( std::floor( allocation.height + .5f ) ), m_depth ) ) {
+		if( !m_render_texture->create( static_cast<unsigned int>( std::floor( allocation.width + .5f ) ), static_cast<unsigned int>( std::floor( allocation.height + .5f ) ), sf::ContextSettings( m_depth ) ) ) {
 #if defined( SFGUI_DEBUG )
 			std::cerr << "SFGUI warning: Canvas failed to create internal SFML RenderTexture.\n";
 #endif
 		}
 	}
 	else if( m_resize ) {
-		if( !m_render_texture->create( static_cast<unsigned int>( std::floor( allocation.width + .5f ) ), static_cast<unsigned int>( std::floor( allocation.height + .5f ) ), m_depth ) ) {
+		if( !m_render_texture->create( static_cast<unsigned int>( std::floor( allocation.width + .5f ) ), static_cast<unsigned int>( std::floor( allocation.height + .5f ) ), sf::ContextSettings( m_depth )) ) {
 #if defined( SFGUI_DEBUG )
 			std::cerr << "SFGUI warning: Canvas failed to create internal SFML RenderTexture.\n";
 #endif

--- a/src/SFGUI/Desktop.cpp
+++ b/src/SFGUI/Desktop.cpp
@@ -115,7 +115,7 @@ void Desktop::Add( std::shared_ptr<Widget> widget ) {
 	RecalculateWidgetLevels();
 
 	if( widget->GetAllocation().contains( static_cast<float>( m_last_mouse_pos.x ), static_cast<float>( m_last_mouse_pos.y ) ) ) {
-		SendFakeMouseMoveEvent( widget, static_cast<float>( m_last_mouse_pos.x ), static_cast<float>( m_last_mouse_pos.y ) );
+		SendFakeMouseMoveEvent( widget, m_last_mouse_pos.x, m_last_mouse_pos.y );
 	}
 
 	// Activate context.
@@ -141,7 +141,7 @@ void Desktop::Remove( std::shared_ptr<Widget> widget ) {
 	RecalculateWidgetLevels();
 
 	if( !m_children.empty() &&  m_children.front()->GetAllocation().contains( static_cast<float>( m_last_mouse_pos.x ), static_cast<float>( m_last_mouse_pos.y ) ) ) {
-		SendFakeMouseMoveEvent( m_children.front(), static_cast<float>( m_last_mouse_pos.x ), static_cast<float>( m_last_mouse_pos.y ) );
+		SendFakeMouseMoveEvent( m_children.front(), m_last_mouse_pos.x, m_last_mouse_pos.y );
 	}
 }
 
@@ -199,7 +199,7 @@ void Desktop::BringToFront( std::shared_ptr<const Widget> child ) {
 	RecalculateWidgetLevels();
 
 	if( child->GetAllocation().contains( static_cast<float>( m_last_mouse_pos.x ), static_cast<float>( m_last_mouse_pos.y ) ) ) {
-		SendFakeMouseMoveEvent( ptr, static_cast<float>( m_last_mouse_pos.x ), static_cast<float>( m_last_mouse_pos.y ) );
+		SendFakeMouseMoveEvent( ptr, m_last_mouse_pos.x, m_last_mouse_pos.y );
 	}
 }
 


### PR DESCRIPTION
- Fixed deprecation warning for sf::RenderWindow::Create() (see [deprecation list](https://www.sfml-dev.org/documentation/2.5.1/deprecated.php))
- Fixed conversion warning for SendFakeMouseMoveEvent calls

Reproduce by building SFGUI with SFML 2.5.x and warnings enabled.