### PR TITLE
Update find script so it finds uppercase library names

### DIFF
--- a/cmake/Modules/FindSFGUI.cmake
+++ b/cmake/Modules/FindSFGUI.cmake
@@ -119,6 +119,7 @@ find_library(
 	SFGUI_LIBRARY_DYNAMIC_RELEASE
 	NAMES
 		sfgui
+		SFGUI
 	PATH_SUFFIXES
 		lib
 		lib64
@@ -130,6 +131,7 @@ find_library(
 	SFGUI_LIBRARY_DYNAMIC_DEBUG
 	NAMES
 		sfgui-d
+		SFGUI-d
 	PATH_SUFFIXES
 		lib
 		lib64
@@ -141,6 +143,7 @@ find_library(
 	SFGUI_LIBRARY_STATIC_RELEASE
 	NAMES
 		sfgui-s
+		SFGUI-s
 	PATH_SUFFIXES
 		lib
 		lib64
@@ -152,6 +155,7 @@ find_library(
 	SFGUI_LIBRARY_STATIC_DEBUG
 	NAMES
 		sfgui-s-d
+		SFGUI-s-d
 	PATH_SUFFIXES
 		lib
 		lib64


### PR DESCRIPTION
I found this was needed when building on Linux, since the libraries are built as `libSFGUI` but the script only looked for `libsfgui`. (Obviously, the other option would be to change the build script to make `libsfgui` instead, but this seemed simpler.)