### PR TITLE
Travis build + Conan dependencies managment

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -ex
+
+command_prefix=()
+
+# Install pre-requisites
+if [ "${TRAVIS_OS_NAME}" = "osx" ];
+then
+    brew update || brew update
+    brew install cmake || :;
+elif [ ! "${TRAVIS_OS_NAME}" = "windows" ];
+then
+    # Start a pre-configured docker image
+    # Images are picked from bincrafters sfml recipe
+    docker pull ${DOCKER_IMAGE}
+    docker run -v ${PWD}:${PWD} -w ${PWD}  \
+               -u root \
+               --name "${RUNNER}" \
+               --rm -t -d ${DOCKER_IMAGE}
+    command_prefix=(docker exec ${RUNNER})
+fi
+
+# Install Conan
+if [ "${TRAVIS_OS_NAME}" = "windows" ];
+then
+    choco install conan || :;
+    export PATH="${PATH}:/c/Program Files/Conan/conan";
+else
+    ${command_prefix[@]} pip install conan --upgrade;
+fi
+
+# Install dependencies using Conan
+conan=(${command_prefix[@]} conan)
+${conan[@]} remote add -f bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+${conan[@]} profile new default --detect  # Generates default profile detecting GCC and sets old ABI
+
+if [ "${TRAVIS_OS_NAME}" = "osx" ];
+then
+    # AppleClang is a bit old, and most recent library is libc++
+    # https://forums.developer.apple.com/thread/73004
+    ${conan[@]} profile update settings.compiler.libcxx=libc++ default
+elif [ "${TRAVIS_OS_NAME}" = "windows" ];
+then
+    # The "--detect" option finds gcc 8, so we set Visual Studio manually
+    ${conan[@]} profile update settings.compiler="Visual Studio" default
+    ${conan[@]} profile update settings.compiler.version=15 default
+
+    # libcxx setting not used on windows
+    ${conan[@]} profile remove settings.compiler.libcxx default
+else
+    # Sets libcxx to C++11 ABI
+    ${conan[@]} profile update settings.compiler.libcxx=libstdc++11 default
+fi
+
+${conan[@]} install . --build missing

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -ex
+
+cmake=("cmake")
+need_stop=false
+if [ "${TRAVIS_OS_NAME}" = "osx" ];
+then
+    generator="-GXcode"
+    CORES=4 # Apple toolchain can't figure out the number of cores...
+elif [ "${TRAVIS_OS_NAME}" = "windows" ];
+then
+    generator="-GVisual Studio 15 2017 Win64"
+else
+    generator="-GNinja"
+    cmake=(docker exec ${RUNNER} cmake)
+    need_stop=true
+fi
+
+build_dir="$(pwd)/build"
+
+# Configure
+${cmake[@]} -H"$(pwd)" -B"${build_dir}" "${generator}" -DCMAKE_BUILD_TYPE=Release
+
+# Compile
+${cmake[@]} --build "${build_dir}" --config Release -j ${CORES:-}
+
+# Stop docker image for linux machine
+if ${need_stop};
+then
+     docker stop "${RUNNER}"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,33 @@
-*.a
-*.o
-*.os
-*.so
+# Documentation artifacts
 /doc/html/
+
+# Build artifacts
 *build*/
-/.vs
-/CMakeSettings.json
+*Build*/
+**.a
+**.o
+**.os
+**.so
+**.lib
+**.dll
+**.dlib
+
+# Conan files
+conan*info.*
+graph_info.json
+
+# Editors cache
+
+## Qt Creator
+CMakeLists.txt.usr
+
+## VSCode
+.vscode
+
+## Visual Studio
+.vs
+
+## Misc
+*~
+*.swp
+CMakeSettings.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+linux: &linux
+   os: linux
+   dist: xenial
+   language: minimal
+   sudo: required
+   services:
+     - docker
+osx: &osx
+   os: osx
+   language: generic
+osx: &windows
+   os: windows
+   language: cpp
+matrix:
+   include:
+      - <<: *linux
+        env: DOCKER_IMAGE=lasote/conangcc8
+      - <<: *linux
+        env: DOCKER_IMAGE=lasote/conanclang60
+      - <<: *osx
+        osx_image: xcode10
+      - <<: *windows
+
+install:
+  # Generate a RUNNER name to use in docker images across install and run
+  - export RUNNER="runner-${RANDOM}"
+  - chmod +x .ci/install.sh
+  - ./.ci/install.sh
+
+script:
+  - chmod +x .ci/run.sh
+  - ./.ci/run.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,17 +13,24 @@ set( SFGUI_VERSION ${SFGUI_MAJOR_VERSION}.${SFGUI_MINOR_VERSION}.${SFGUI_REVISIO
 
 ### USER INPUT ###
 
+option( SFGUI_BUILD_EXAMPLES    "Build examples."                               ON )
+option( SFGUI_BUILD_DOC         "Generate API documentation."                   OFF )
+option( SFGUI_INCLUDE_FONT      "Include default font in library (DejaVuSans)." ON )
 option( SFGUI_BUILD_SHARED_LIBS "Build shared library."                         ON )
 set( BUILD_SHARED_LIBS ${SFGUI_BUILD_SHARED_LIBS} )
-option( SFGUI_BUILD_EXAMPLES    "Build examples."                               ON)
-option( SFGUI_BUILD_DOC         "Generate API documentation."                   OFF)
-option( SFGUI_INCLUDE_FONT      "Include default font in library (DejaVuSans)." ON)
-option( SFML_STATIC_LIBRARIES   "Do you want to link SFML statically?"          OFF)
 
 
 # Find packages.
 find_package( OpenGL REQUIRED )
-find_package( SFML 2.5 REQUIRED COMPONENTS graphics window system )
+if ( EXISTS ${CMAKE_SOURCE_DIR}/conanbuildinfo.cmake )
+	include( ${CMAKE_SOURCE_DIR}/conanbuildinfo.cmake )
+	conan_basic_setup()
+else ()
+	option( SFML_STATIC_LIBRARIES   "Do you want to link SFML statically?" OFF)
+	find_package( SFML 2.5 REQUIRED COMPONENTS graphics window system )
+	set( SFML_LIBRARIES sfml-graphics )
+endif()
+
 
 set( INCLUDE_PATH "${PROJECT_SOURCE_DIR}/include/" )
 set( SOURCE_PATH "${PROJECT_SOURCE_DIR}/src/" )
@@ -56,7 +63,7 @@ if( SFGUI_INCLUDE_FONT )
 	target_compile_definitions( ${TARGET} PRIVATE SFGUI_INCLUDE_FONT )
 endif()
 
-target_link_libraries( ${TARGET} PUBLIC sfml-graphics sfml-window sfml-system ${OPENGL_gl_LIBRARY} )
+target_link_libraries( ${TARGET} PUBLIC ${CONAN_LIBS} ${SFML_LIBRARIES} ${OPENGL_gl_LIBRARY} )
 
 # Tell the compiler to export when necessary.
 set_target_properties( ${TARGET} PROPERTIES DEFINE_SYMBOL SFGUI_EXPORTS )
@@ -105,17 +112,12 @@ if( WIN32 )
 	set( SHARE_PATH "." )
 	set( LIB_PATH "lib" )
 elseif( APPLE )
+	# Apple Frameworks being nice bundles, CMake directly interpret them as targets!
 	find_library( COREFOUNDATION_LIBRARY CoreFoundation )
 	mark_as_advanced( COREFOUNDATION_LIBRARY )
 
-	add_library( CoreFoundation SHARED IMPORTED )
-	set_target_properties(
-		CoreFoundation PROPERTIES
-			IMPORTED_LOCATION "${COREFOUNDATION_LIBRARY}"
-			INTERFACE_INCLUDE_DIRECTORIES "/System/Library/Frameworks/CoreFoundation.framework/Headers"
-	)
-	
-	target_link_libraries( ${TARGET} PUBLIC CoreFoundation )
+	target_link_libraries( ${TARGET} PUBLIC ${COREFOUNDATION_LIBRARY} )
+
 	set( SHARE_PATH "${CMAKE_INSTALL_PREFIX}/share/SFGUI" )
 	set( LIB_PATH "lib" )
 elseif( "${CMAKE_SYSTEM_NAME}" MATCHES "Linux" )

--- a/README.md
+++ b/README.md
@@ -25,36 +25,92 @@ Building SFGUI is only required in the following cases:
     website, nor in your operating system's software archives.
   * You want to adjust SFGUI to your likings or help with development.
 
-At first, download and install the dependencies:
+### Tools needed
 
-  * [SFML](http://sfml-dev.org/)
-  * [CMake](http://cmake.org/)
+  * [CMake](http://cmake.org/), it is recommended to make yourself familiar with
+    CMake and how it works.
+  * [Conan](https://conan.io/) (**Optional**, use it to get all the project dependencies)
+  * **C++11 compatible compiler**.
+    > When using **conan**, make sure that your compiler is compatible with the
+    packages downloaded. For example, when using Visual Studio 15 2017 on a modern
+    machine, conan will download 64 bits libraries. If you want to use the 32 bits
+    ABI (Win32), you will need to change your conan profile accordingly.
 
-Make yourself familiar with CMake and how it works.
+### Dependencies
 
-Then create a new directory `build`, start CMake (GUI), choose that directory
-as your build directory and SFGUI's directory as source code directory.
+Only [SFML](http://sfml-dev.org/) is required. You can install it with most operating
+system package managers, and rely on cmake mechanisms to find and configure your project.
+Here is how to use conan to get it:
 
-Hit _Configure_ followed by _Generate_. Close CMake.
+  1. Add [bincrafters](https://bincrafters.github.io/) repository to your conan
+     configuration
+     ```
+     conan remote add -f bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+     ```
+     > Bincrafters is a repository of packages pending addition to conan official server.
+  2. From the SFGUI repository, use conan to install dependencies
+     ```
+     conan install .
+     ```
 
-Finally either open the project files you have generated with CMake (e.g.
-Visual Studio solution) or instruct the chosen Make tool to build SFGUI, for
-example GNU Make:
+### Build!
+  1. Configure using CMake:
+     ```
+     cmake -H. -Bbuild
+     ```
+     > `-H` specifies the path to your sources. On windows, I had better luck with `".\"`.
+     
+     > `-B` is the path to the build directory, name it as you see fit, place it
+     where your fancy strickes you, it doesn't need to be among the sources.
+     CMake will fix all the paths for you.
 
-  * `make install` (as root)
+     You can use `cmake-gui` to have a convenient configuration interface.
+     You need to _Configure_ and _Generate_ the build information by clicking on the buttons.
+     It will not help with the compilation step.
+  2. Build
+      ```
+      cmake --build build
+      ```
+      > This magic cross-compilation-fits-all command will use the selected generator
+        to build your project! No need to fire up any IDE, you can work from your favorite
+        text editor in peace.
+  3. (Optional) Install
+     ```
+     cmake --build build --target install
+     ```
+     > CMake registers this project locally so that other CMake projects can find it.
 
-On Linux and after installing, you have to update _ld's_ library cache by
-running `ldconfig` as root.
+     Depending on how you configured `CMAKE_INSTALL_PREFIX` (`/usr/local` on linux
+     by default, `C:/Program Files/SFGUI` on windows), you man need administrator access
+     to run the command (`sudo` on linux).
+
+     > On Linux and after installing, you may want to update _ld's_ library cache
+       by running `ldconfig` as root.
 
 ## Using SFGUI in other CMake-powered projects
 
-Projects using CMake within the build process can make use of SFGUI's
-[_FindSFGUI.txt_](https://github.com/TankOs/SFGUI/blob/master/cmake/Modules/FindSFGUI.cmake)
-file. Copy that file into your CMake _Modules_ directory (located in CMake's
-directory on Windows, or in _/usr/share/cmake-x.y/Modules/_).
+### In your `CMakeList.txt`
 
-Instructions on how to use and configure the script can be found right at the
-top of the file in the comment section.
+```cmake
+find_package(SFGUI 0.4.0 REQUIRED)
+# ...
+add_executable(SuperGameProject ${CPPS})
+# ...
+target_link_libraries(SuperGameProject PRIVATE SFGUI::SFGUI)
+```
+
+### A word on how `find_package` works:
+
+This project auto-magically register itself locally, so you don't even need to
+install for `find_package` to find it! If you installed at a standard path,
+`find_package` will also be able to find the configuration.
+
+However, if you did not install at a standard path or have several versions of SFGUI,
+you will need to provide configure the CMake variable `SFGUI_DIR` to `cmake`.
+The value is _the path to the directory containing `SFGUIConfig.cmake`_.
+
+On unix systems, it is usually under `<CMAKE_PREFIX_PATH>/share/cmake/SFGUI`,
+eg: `/usr/local/share/cmake/SFGUI` (this path should be looked up by default.)
 
 ## Contributing
 
@@ -71,3 +127,4 @@ contribution, please add yourself to the list.
 
   * Website: https://github.com/TankOs/SFGUI
   * IRC: [irc.boxbox.org:6697, #sfgui](irc://irc.sfml-dev.org:6697/#sfgui)
+  * Discord: [SFML server](https://discord.gg/nr4X7Fh)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,9 @@
+[requires]
+sfml/2.5.1@bincrafters/stable
+
+[options]
+sfml:graphics=True
+sfml:window=True
+
+[generators]
+cmake

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required( VERSION 3.2 )
 
 function( build_example SAMPLE_NAME SOURCES )
 	add_executable( ${SAMPLE_NAME} ${SOURCES} )


### PR DESCRIPTION
[![Build Status](https://travis-ci.org/DrBarbare/SFGUI.svg?branch=feature%2Fconan-dependencies-managment)](https://travis-ci.org/DrBarbare/SFGUI)
> IMPORTANT: A Travis account will be needed to use the CI pipeline. 

## Features
- Added a Conan configuration file to easily get SFML
- Added Travis configuration (Ubuntu, OSX and Windows) with scripts to configure and build the project (no test stage)
- Update the Readme to reflect changes in workflow
- Minor changes in CMake configuration to support Conan
- Fixes in CMake configuration revealed by Travis
- Upgraded `.gitignore`

## Known issues
- Travis job does not run any tests at the moment, only builds

## To test

Everything should be in the update documentation. You should still be able to work on the project without the need of Conan, it does make it easier.