### PR TITLE
Fix static std libs in MinSizeRel and RelWithDebInfo configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,9 @@ if( WIN32 )
 			target_compile_definitions( ${TARGET} PUBLIC SFML_STATIC )
 
 			if( MSVC )
-				foreach( flag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE )
+				foreach(flag
+						CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+						CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
 					if( ${flag} MATCHES "/MD" )
 					string( REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}" )
 					endif()


### PR DESCRIPTION
They were compiled with /MD instead of /MT in MSVC