### PR TITLE
add OnEnterKeyPressed signal to Entry widget

### DIFF
--- a/include/SFGUI/Entry.hpp
+++ b/include/SFGUI/Entry.hpp
@@ -89,6 +89,7 @@ class SFGUI_API Entry : public Widget {
 
 		// Signals.
 		static Signal::SignalID OnTextChanged; //!< Fired when the text changes.
+		static Signal::SignalID OnEnterKeyPressed; //!< Fired when the enter key was pressed.
 
 	protected:
 		/** Ctor.

--- a/src/SFGUI/Entry.cpp
+++ b/src/SFGUI/Entry.cpp
@@ -10,6 +10,7 @@ namespace sfg {
 
 // Signals.
 Signal::SignalID Entry::OnTextChanged = 0;
+Signal::SignalID Entry::OnEnterKeyPressed = 0;
 
 Entry::Entry() :
 	m_string(),
@@ -179,7 +180,10 @@ void Entry::HandleKeyEvent( sf::Keyboard::Key key, bool press ) {
 	}
 
 	switch( key ) {
-	case sf::Keyboard::BackSpace: { // backspace
+	case sf::Keyboard::Enter: {
+		GetSignals().Emit( OnEnterKeyPressed );
+	} break;
+	case sf::Keyboard::Backspace: {
 		if( ( m_string.getSize() > 0 ) && ( m_cursor_position > 0 ) ) {
 			m_string.erase( static_cast<std::size_t>( m_cursor_position - 1 ) );
 


### PR DESCRIPTION
This PR adds new signal to Entry widget. Signal get fired when the "Enter" key is pressed. This seams to be usefull when you want to create entry and do some action on this specyfic key press.