### PR TITLE
Fix the macOS build for 10.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,16 +107,8 @@ if( WIN32 )
 	set( LIB_PATH "lib" )
 elseif( APPLE )
 	find_library( COREFOUNDATION_LIBRARY CoreFoundation )
-	mark_as_advanced( COREFOUNDATION_LIBRARY )
 
-	add_library( CoreFoundation SHARED IMPORTED )
-	set_target_properties(
-		CoreFoundation PROPERTIES
-			IMPORTED_LOCATION "${COREFOUNDATION_LIBRARY}"
-			INTERFACE_INCLUDE_DIRECTORIES "/System/Library/Frameworks/CoreFoundation.framework/Headers"
-	)
-	
-	target_link_libraries( ${TARGET} PUBLIC CoreFoundation )
+	target_link_libraries( ${TARGET} PUBLIC ${COREFOUNDATION_LIBRARY} )
 	set( SHARE_PATH "${CMAKE_INSTALL_PREFIX}/share/SFGUI" )
 	set( LIB_PATH "lib" )
 elseif( "${CMAKE_SYSTEM_NAME}" MATCHES "Linux" )


### PR DESCRIPTION
The explicit way of linking CoreFoundation used in the existing
CMakeLists.txt does not work on 10.15, and we can simplify it. The code
I used is based on a StackOverflow comment, and does work on my machine;
It builds, and HelloWorld runs perfectly well.

fixes #81 