### PR TITLE
+ missed <limits> for std::numeric_limits

### DIFF
--- a/src/SFGUI/ComboBox.cpp
+++ b/src/SFGUI/ComboBox.cpp
@@ -9,6 +9,8 @@
 #include <SFML/System/String.hpp>
 #include <SFML/Window/Event.hpp>
 
+#include <limits>
+
 namespace sfg {
 
 // Signals.


### PR DESCRIPTION
W/o `<limits>` this file might not be compiled in some environments, depending on the order of compilation.